### PR TITLE
2026.3.1: Update Intel Compute Runtime to v26.05

### DIFF
--- a/fastsd-cpu/CHANGELOG.md
+++ b/fastsd-cpu/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026.3.1 - 2026-03-16
+
+Update Intel Compute Runtime
+* oneAPI Level Zero Loader v1.28.2
+* Intel Graphics Compiler v2.28.4
+* Intel Compute Runtime v26.05
+
 ## 2025.11.1 - 2025-11-16
 
 - Remove deprecated `codenotary` fields

--- a/fastsd-cpu/Dockerfile
+++ b/fastsd-cpu/Dockerfile
@@ -34,16 +34,16 @@ RUN \
 RUN \
     mkdir -p /tmp/gpu && \
     cd /tmp/gpu && \
-    echo "Downloading oneAPI Level Zero Loader v1.24.2..." && \
-    wget https://github.com/oneapi-src/level-zero/releases/download/v1.24.2/level-zero_1.24.2+u24.04_amd64.deb && \
-    echo "Downloading Intel Graphics Compiler v2.16.0..." && \
-    wget https://github.com/intel/intel-graphics-compiler/releases/download/v2.16.0/intel-igc-core-2_2.16.0+19683_amd64.deb && \
-    wget https://github.com/intel/intel-graphics-compiler/releases/download/v2.16.0/intel-igc-opencl-2_2.16.0+19683_amd64.deb && \
-    echo "Downloading Intel Compute Runtime v25.31..." && \
-    wget https://github.com/intel/compute-runtime/releases/download/25.31.34666.3/intel-ocloc_25.31.34666.3-0_amd64.deb && \
-    wget https://github.com/intel/compute-runtime/releases/download/25.31.34666.3/intel-opencl-icd_25.31.34666.3-0_amd64.deb && \
-    wget https://github.com/intel/compute-runtime/releases/download/25.31.34666.3/libigdgmm12_22.8.1_amd64.deb && \
-    wget https://github.com/intel/compute-runtime/releases/download/25.31.34666.3/libze-intel-gpu1_25.31.34666.3-0_amd64.deb && \
+    echo "Downloading oneAPI Level Zero Loader v1.28.2..." && \
+    wget https://github.com/oneapi-src/level-zero/releases/download/v1.28.2/level-zero_1.28.2+u24.04_amd64.deb && \
+    echo "Downloading Intel Graphics Compiler v2.28.4..." && \
+    wget https://github.com/intel/intel-graphics-compiler/releases/download/v2.28.4/intel-igc-core-2_2.28.4+20760_amd64.deb && \
+    wget https://github.com/intel/intel-graphics-compiler/releases/download/v2.28.4/intel-igc-opencl-2_2.28.4+20760_amd64.deb && \
+    echo "Downloading Intel Compute Runtime v26.05..." && \
+    wget https://github.com/intel/compute-runtime/releases/download/26.05.37020.3/intel-ocloc_26.05.37020.3-0_amd64.deb && \
+    wget https://github.com/intel/compute-runtime/releases/download/26.05.37020.3/intel-opencl-icd_26.05.37020.3-0_amd64.deb && \
+    wget https://github.com/intel/compute-runtime/releases/download/26.05.37020.3/libigdgmm12_22.9.0_amd64.deb && \
+    wget https://github.com/intel/compute-runtime/releases/download/26.05.37020.3/libze-intel-gpu1_26.05.37020.3-0_amd64.deb && \
     dpkg -i --force-all *.deb && \
     rm *.deb
 

--- a/fastsd-cpu/config.yaml
+++ b/fastsd-cpu/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: FastSD CPU
-version: 2025.11.1
+version: 2026.3.1
 slug: fastsd-cpu
 description: FastSD CPU is a faster version of Stable Diffusion on CPU
 url: https://github.com/andrewjswan/fastsd-cpu-addon/


### PR DESCRIPTION
* oneAPI Level Zero Loader v1.28.2
* Intel Graphics Compiler v2.28.4
* Intel Compute Runtime v26.05